### PR TITLE
HFP-2954 Fix apostrophe on iOS

### DIFF
--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -298,7 +298,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
             '</div>' +
             '<div class="h5p-answer">' +
               '<div class="h5p-input">' +
-                '<input type="text" class="h5p-textinput" tabindex="-1" placeholder="' + this.options.defaultAnswerText + '" aria-describedby="h5p-flashcard-card-' + cardId +'" autocomplete="off"/>' +
+                '<input type="text" class="h5p-textinput" tabindex="-1" placeholder="' + this.options.defaultAnswerText + '" aria-describedby="h5p-flashcard-card-' + cardId +'" autocomplete="off" spellcheck="false"/>' +
                 '<button type="button" class="h5p-button h5p-check-button" tabindex="-1" title="' + this.options.checkAnswerText + '">' + this.options.checkAnswerText + '</button>' +
                 '<button type="button" class="h5p-button h5p-icon-button" tabindex="-1" title="' + this.options.checkAnswerText + '"/>' +
               '</div>' +


### PR DESCRIPTION
The virtual keyboard of iOS does not produce an apostrophe, but a left single quotation mark or a right single quotation mark if it is using smart quotes. Can be turned off by setting the input fields' spellcheck attribute to false.