### PR TITLE
HFP-3461 Fix announcement of correct answers

### DIFF
--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -38,6 +38,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
       retry : "Retry",
       cardAnnouncement: 'Incorrect answer. Correct answer was @answer',
       pageAnnouncement: 'Page @current of @total',
+      correctAnswerAnnouncement: '@answer is correct!',
     }, options);
     this.$images = [];
     this.hasBeenReset = false;
@@ -351,19 +352,19 @@ H5P.Flashcards = (function ($, XapiGenerator) {
         if (userCorrect) {
           $input.parent()
             .addClass('h5p-correct')
-            .append('<div class="h5p-feedback-label" tabindex="-1" aria-label="' + that.options.correctAnswerText + '">' + that.options.correctAnswerText + '!</div>');
+            .append('<div class="h5p-feedback-label">' + that.options.correctAnswerText + '!</div>');
           $card.addClass('h5p-correct');
 
           $('<div class="h5p-solution">' +
             '<span class="solution-icon h5p-rotate-in"></span>' +
           '</div>').appendTo($card.find('.h5p-imageholder'));
 
-          $input.siblings('.h5p-feedback-label').focus();
+          that.$ariaAnnouncer.html(that.options.correctAnswerAnnouncement.replace('@answer', userAnswer));
         }
         else {
           $input.parent()
             .addClass('h5p-wrong')
-            .append('<span class="h5p-feedback-label" tabindex="-1" aria-label="' + that.options.incorrectAnswerText + '">' + that.options.incorrectAnswerText + '!</span>');
+            .append('<span class="h5p-feedback-label">' + that.options.incorrectAnswerText + '!</span>');
           $card.addClass('h5p-wrong');
 
           $('<div class="h5p-solution">' +

--- a/language/.en.json
+++ b/language/.en.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/.en.json
+++ b/language/.en.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/af.json
+++ b/language/af.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/af.json
+++ b/language/af.json
@@ -107,6 +107,11 @@
       "description": "Teks wat vertoon sal word vir hulptegnologieë. Gebruik @answer as veranderlike."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Kaartjie verandering vir hulptegnologieë",
       "default": "Bladsy @current van @total",
       "description": "Teks wat aangekondig sal word as hulptegnologieë wanneer u tussen kaarte navigeer. Gebruik @current en @total as veranderlikes."

--- a/language/ar.json
+++ b/language/ar.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ar.json
+++ b/language/ar.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/bg.json
+++ b/language/bg.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/bg.json
+++ b/language/bg.json
@@ -107,6 +107,11 @@
       "description": "Текст, предназначен за помощните технологии. Използвайте @answer като променлива."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Смяна на картата за помощни техмологии",
       "default": "Страница @current от @total",
       "description": "Текстът ще се показва при движение между картите и използване на помощни технологии. Използвайте @current и @total като променливи."

--- a/language/bs.json
+++ b/language/bs.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/bs.json
+++ b/language/bs.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Stranica @current od @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/ca.json
+++ b/language/ca.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ca.json
+++ b/language/ca.json
@@ -107,6 +107,11 @@
       "description": "Text que s’anunciarà a les tecnologies d’assistència. S’utilitza @answer com a variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Canvi de targeta per a les tecnologies d’assistència",
       "default": "Pàgina @current de @total",
       "description": "Text que s’anunciarà a les tecnologies d’assistència en navegar per les targetes. S’utilitza @current i @total com a variables."

--- a/language/cs.json
+++ b/language/cs.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/cs.json
+++ b/language/cs.json
@@ -107,6 +107,11 @@
       "description": "Text, který bude oznámen pomocnými technologiemi. Jako proměnnou použijte @answer."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Změna karty za pomocné technologie",
       "default": "Strana @current z @total",
       "description": "Text, který bude při navigaci mezi kartami oznámen pomocnými technologiemi. Jako proměnné použijte @current a @total."

--- a/language/da.json
+++ b/language/da.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/da.json
+++ b/language/da.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/de.json
+++ b/language/de.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/de.json
+++ b/language/de.json
@@ -107,6 +107,11 @@
       "description": "Text, der von Vorlesewerkzeugen vorgelesen wird (Barrierefreiheit). Verwende @answer als Platzhalter."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Text zum Kartenwechsel für Vorlesewerkzeuge",
       "default": "Karte @current von @total",
       "description": "Text, der von Vorlesewerkzeugen vorgelesen wird, wenn zwischen Karten gewechselt wird (Barrierefreiheit). Verwende @current und @total als Platzhalter."

--- a/language/el.json
+++ b/language/el.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/el.json
+++ b/language/el.json
@@ -107,6 +107,11 @@
       "description": "Κείμενο που θα χρησιμοποιηθεί από υποστηρικτικές τεχνολογίες. Χρησιμοποιήστε τη μεταβλητή @answer."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Κείμενο τρέχουσας κάρτας για υποστηρικτικές τεχνολογίες",
       "default": "Κάρτα @current από @total",
       "description": "Κείμενο που θα χρησιμοποιηθεί από υποστηρικτικές τεχνολογίες κατά την πλοήγηση μεταξύ των καρτών. Χρησιμοποιήστε τις μεταβλητές @current, @total."

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -107,6 +107,11 @@
       "description": "Texto que será anunciado a tecnologías asistivas. Use @answer como variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Cambio de Tarjeta para tecnologías asistivas",
       "default": "Página @current de @total",
       "description": "Texto que será anunciado a tecnologías asistivas al navegar entre cartas. Use @current y @total como variables."

--- a/language/es.json
+++ b/language/es.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/es.json
+++ b/language/es.json
@@ -107,6 +107,11 @@
       "description": "Texto que será anunciado a tecnologías asistivas. Use @answer como variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Cambio de Tarjeta para tecnologías asistivas",
       "default": "Página @current de @total",
       "description": "Texto que será anunciado a tecnologías asistivas al navegar entre cartas. Use @current y @total como variables."

--- a/language/et.json
+++ b/language/et.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/et.json
+++ b/language/et.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/eu.json
+++ b/language/eu.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/eu.json
+++ b/language/eu.json
@@ -107,6 +107,11 @@
       "description": "Laguntzarako teknologietan erabiliko den testua. Erabili @answer aldagai gisa."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Txartel aldaketa laguntzarako teknologientzat",
       "default": "@current. orria, @total guztira",
       "description": "Laguntzarako teknologietan txartel artean nabigatzean erabiliko den testua. Erabili @current eta @total aldagai gisa."

--- a/language/fi.json
+++ b/language/fi.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/fi.json
+++ b/language/fi.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/fr.json
+++ b/language/fr.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/fr.json
+++ b/language/fr.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/gl.json
+++ b/language/gl.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/gl.json
+++ b/language/gl.json
@@ -107,6 +107,11 @@
       "description": "O texto pasarase ás tecnoloxías de asistencia. Usa @answer como variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Cambio de tarxeta para as tecnoloxías de asistencia",
       "default": "Páxina @current de @total",
       "description": "O texto pasarase ás tecnoloxías de asistencia cando se navegue entre tarxetas. Usa @current e @total como variables."

--- a/language/he.json
+++ b/language/he.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/he.json
+++ b/language/he.json
@@ -107,6 +107,11 @@
       "description": "תוכן יוקרא בקול לטכנולוגיות מסייעות. השתמשו ב- answer@ כמשתנה."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "החלפת כרטיס עבור טכנולוגיות מסייעות",
       "default": "דף current@ מתוך total@",
       "description": "תוכן שיוקרא לטכנולוגיות מסייעות בעת ניווט בין כרטיסים. השתמשו ב- current@ ו- total@ כמשתנים."

--- a/language/hu.json
+++ b/language/hu.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/hu.json
+++ b/language/hu.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/it.json
+++ b/language/it.json
@@ -107,6 +107,11 @@
       "description": "Testo per le tecnologie assistive. Usa @answer come variabile"
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Cambio scheda per le tecnologie assistive",
       "default": "Pagina @current di @total",
       "description": "Testo per le tecnologie assistive durante la navigazione tra schede. Usa @current e @total come variabili"

--- a/language/it.json
+++ b/language/it.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ja.json
+++ b/language/ja.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ja.json
+++ b/language/ja.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/ka.json
+++ b/language/ka.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ka.json
+++ b/language/ka.json
@@ -107,6 +107,11 @@
       "description": "ტექსტი, რომელსაც კითხულობს დამხმარე ტექნოლოგია. @answer-ის გამოყენება ცვლადის სახით."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "ბარათის შეცვლა დამხმარე ტექნოლოგიისთვის",
       "default": "@current ბარათი @total-დან",
       "description": "ტექსტი, რომელსაც კითხულობს დამხმარე ტექნოლოგია ბარათის შეცვლისას. @current-ისა და @total-ის გამოყენება ცვლადების სახით."

--- a/language/km.json
+++ b/language/km.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/km.json
+++ b/language/km.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "ទំព័រ @current ចំណោម @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/ko.json
+++ b/language/ko.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ko.json
+++ b/language/ko.json
@@ -107,6 +107,11 @@
       "description": "보조 기술로 말해지는 텍스트. @answer 을(를) 변수로 사용하세요."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "보조 기술을 위한 카드 변경",
       "default": "총 @total 중 현재 페이지 @current",
       "description": "카드간 이동에서 보조 기술로 말해지는 텍스트. @current 와 @total 를 변수로 사용하세요."

--- a/language/nb.json
+++ b/language/nb.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/nb.json
+++ b/language/nb.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/nl.json
+++ b/language/nl.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/nl.json
+++ b/language/nl.json
@@ -107,6 +107,11 @@
       "description": "Tekst die wordt gebruikt door ondersteunende technologieën. Gebruik @answer als variabele."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Kaart wijzigen voor ondersteunende technologieën",
       "default": "Pagina @current van @total",
       "description": "Tekst die wordt gebruikt door ondersteunende technologieën als van kaart wordt gewisseld. Gebruik @current en @total als variabelen."

--- a/language/nn.json
+++ b/language/nn.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/nn.json
+++ b/language/nn.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Side @current av @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/pl.json
+++ b/language/pl.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/pl.json
+++ b/language/pl.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Strona @current z @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/pt.json
+++ b/language/pt.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/pt.json
+++ b/language/pt.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/ro.json
+++ b/language/ro.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ro.json
+++ b/language/ro.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/ru.json
+++ b/language/ru.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/ru.json
+++ b/language/ru.json
@@ -107,6 +107,11 @@
       "description": "Текст, объявляемый ассистирующими технологиями. Использовать @answer в качестве переменной."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Смена карточки для ассистирующих технологии",
       "default": "Карточка @current из @total",
       "description": "Текст, объявляемый ассистирующими технологиями при смене карточек. Использовать @current и @total в качестве переменных."

--- a/language/sl.json
+++ b/language/sl.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/sl.json
+++ b/language/sl.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/sma.json
+++ b/language/sma.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/sma.json
+++ b/language/sma.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/sme.json
+++ b/language/sme.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/sme.json
+++ b/language/sme.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/smj.json
+++ b/language/smj.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/smj.json
+++ b/language/smj.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/sr.json
+++ b/language/sr.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/sr.json
+++ b/language/sr.json
@@ -107,6 +107,11 @@
       "description": "Текст који ће бити најављен за помоћне технологије. Користите @answer као променљиву."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Промена картице за помоћне технологије",
       "default": "Страна @current од @total",
       "description": "Текст који ће бити најављен помоћним технологијама приликом навигације између картица. Користите @current и @total као променљиве."

--- a/language/sv.json
+++ b/language/sv.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/sv.json
+++ b/language/sv.json
@@ -107,6 +107,11 @@
       "description": "Text som kommer användas av tillgänglighetshjälpmedel. Använd @answer som variabel."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Byte av kort vid tillgänglighetshjälpmedel",
       "default": "Sida @current av @total",
       "description": "Text som kommer användas av tillgänglighetshjälpmedel vid navigering mellan kort. Använd @current och @total som variabler."

--- a/language/tr.json
+++ b/language/tr.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/tr.json
+++ b/language/tr.json
@@ -107,6 +107,11 @@
       "description": "Yardımcı teknolojilere cevabın yanlış olduğunu ve doğru cevabı duyuracak metin. @answer ifadesini yerine doğru cevabın gelmesi için kullanın."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Yardımcı teknolojiler için kart değişikliği",
       "default": "@total sayfadan @current. sayfa",
       "description": "Kartlar arasında gezinirken yardımcı teknolojilere toplam sayfa sayısını ve bulunulan sayfayı duyuracak metin. Toplam sayfa sayısı içi @total, bulunulan sayfa için de @current kullanın."

--- a/language/uk.json
+++ b/language/uk.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/uk.json
+++ b/language/uk.json
@@ -107,6 +107,11 @@
       "description": "Текст, який буде оголошено допоміжними технологіями. Використовуйте @answer як змінну."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Зміна картки для допоміжних технологій",
       "default": "Сторінка @current з @total",
       "description": "Текст, який буде оголошено допоміжними технологіями під час навігації між картками. Використовуй @current і @total як змінні."

--- a/language/vi.json
+++ b/language/vi.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/vi.json
+++ b/language/vi.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -108,7 +108,7 @@
     },
     {
       "label": "Correct feedback text for assistive technologies",
-      "default": "@answer is correct. Correct answer was @answer",
+      "default": "@answer is correct.",
       "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
     },
     {

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -107,6 +107,11 @@
       "description": "Text that will be announced to assistive technologies. Use @answer as variable."
     },
     {
+      "label": "Correct feedback text for assistive technologies",
+      "default": "@answer is correct. Correct answer was @answer",
+      "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable."
+    },
+    {
       "label": "Card change for assistive technologies",
       "default": "Page @current of @total",
       "description": "Text that will be announced to assistive technologies when navigating between cards. Use @current and @total as variables."

--- a/semantics.json
+++ b/semantics.json
@@ -215,7 +215,7 @@
     "label": "Correct feedback text for assistive technologies",
     "name": "correctAnswerAnnouncement",
     "type": "text",
-    "default": "@answer is correct. Correct answer was @answer",
+    "default": "@answer is correct.",
     "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable.",
     "common": true
   },

--- a/semantics.json
+++ b/semantics.json
@@ -212,6 +212,14 @@
     "common": true
   },
   {
+    "label": "Correct feedback text for assistive technologies",
+    "name": "correctAnswerAnnouncement",
+    "type": "text",
+    "default": "@answer is correct. Correct answer was @answer",
+    "description": "Text that will be announced to assistive technologies when a card is answered correctly. Use @answer as variable.",
+    "common": true
+  },
+  {
     "label": "Card change for assistive technologies",
     "name": "pageAnnouncement",
     "type": "text",


### PR DESCRIPTION
This uses the same technique that was already being used for announcing
when the answer is incorrect. The bonus is that this seems to work more
consistently in several screen readers, whereas the previous solution did
not seem to be working with JAWS 2022.