### PR TITLE
HFP-3780 flashcards screen reader confused by card transitions

### DIFF
--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -331,7 +331,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
       '<div role="group" aria-roledescription="slide" aria-labelledby="h5p-flashcard-card-' + cardId + '" class="h5p-card h5p-animate' + (index === 0 ? ' h5p-current' : '') + '"> ' +
         '<div class="h5p-cardholder">' +
           '<div class="h5p-imageholder">' +
-            '<div class="h5p-flashcard-overlay">' +
+            '<div class="h5p-flashcard-overlay" tabindex="-1">' +
             '</div>' +
           '</div>' +
           '<div class="h5p-foot">' +
@@ -352,7 +352,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     $card.find('.h5p-imageholder').prepend(this.$images[index]);
 
-    $card.prepend($('<div class="h5p-flashcard-overlay" tabindex="0"></div>').on('click', function () {
+    $card.prepend($('<div class="h5p-flashcard-overlay" tabindex="-1"></div>').on('click', function () {
       
       // Set temporary focus
       $card.find('.h5p-flashcard-overlay').focus();
@@ -603,10 +603,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
     $card.removeClass('h5p-previous h5p-next');
     $card.addClass('h5p-current');
     $card.attr('aria-hidden', 'false');
-
-    // Set unreacable for tab button
-    $card.find('.h5p-flashcard-overlay').attr('tabindex', '-1');
-    $card.siblings().find('.h5p-flashcard-overlay').attr('tabindex', '-1');
 
     $card.siblings()
       .removeClass('h5p-current h5p-previous h5p-next left right')

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -572,10 +572,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
    *   Class to add to existing current card.
    */
   C.prototype.setCurrent = function ($card) {
-    
-    // Set unreachable for tab button
-    $card.find('.h5p-flashcard-overlay').attr('tabindex', '-1');
-
     // Remove from existing card.
     if (this.$current) {
       this.$current.attr('aria-hidden', 'true');
@@ -587,6 +583,10 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     // Set new card
     this.$current = $card;
+
+    // Set unreacable for tab button
+    this.$current.find('.h5p-flashcard-overlay').attr('tabindex', '-1');
+    this.$current.siblings().find('.h5p-flashcard-overlay').attr('tabindex', '-1');
 
     /* We can't set focus on anything until the transition is finished.
        If we do, iPad will try to center the focused element while the transition

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -596,7 +596,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
        is running, and the card will be misplaced */
     $card.one('transitionend', function () {
       if ($card.hasClass('h5p-current') && !$card.find('.h5p-textinput')[0].disabled) {
-        $card.attr('aria-hidden', 'false');
         $card.find('.h5p-textinput').focus();
       }
       setTimeout(function () {
@@ -607,6 +606,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
     // Update card classes
     $card.removeClass('h5p-previous h5p-next');
     $card.addClass('h5p-current');
+    $card.attr('aria-hidden', 'false');
 
     $card.siblings()
       .removeClass('h5p-current h5p-previous h5p-next left right')

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -328,7 +328,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     // Generate a new flashcards html and add it to h5p-inner
     var $card = $(
-      '<div role="group" class="h5p-card h5p-animate' + (index === 0 ? ' h5p-current' : '') + '"> ' +
+      '<div role="group" aria-roledescription="slide" aria-labelledby="h5p-flashcard-card-' + cardId + '" class="h5p-card h5p-animate' + (index === 0 ? ' h5p-current' : '') + '"> ' +
         '<div class="h5p-cardholder">' +
           '<div class="h5p-imageholder">' +
             '<div class="h5p-flashcard-overlay">' +

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -383,15 +383,16 @@ H5P.Flashcards = (function ($, XapiGenerator) {
       var userCorrect = isCorrectAnswer(card, userAnswer, that.options.caseSensitive);
       var done = false;
 
-      // Set temporary focus
-      $card.find('.h5p-flashcard-overlay').focus();
-
       if (userAnswer == '') {
         $input.focus();
       }
 
       if (!that.options.showSolutionsRequiresInput || userAnswer !== '' || userCorrect) {
         that.numAnswered++;
+        
+        // Set temporary focus
+        $card.find('.h5p-flashcard-overlay').focus();
+        
         $input.add(this).attr('disabled', true);
 
         that.answers[index] = userAnswer;
@@ -577,7 +578,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
   C.prototype.setCurrent = function ($card) {
     // Remove from existing card.
     if (this.$current) {
-      this.$current.attr('aria-hidden', 'true');
       this.$current.find('.h5p-textinput').attr('tabindex', '-1');
       this.$current.find('.joubel-tip-container').attr('tabindex', '-1');
       this.$current.find('.h5p-check-button').attr('tabindex', '-1');
@@ -586,10 +586,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     // Set new card
     this.$current = $card;
-
-    // Set unreacable for tab button
-    this.$current.find('.h5p-flashcard-overlay').attr('tabindex', '-1');
-    this.$current.siblings().find('.h5p-flashcard-overlay').attr('tabindex', '-1');
 
     /* We can't set focus on anything until the transition is finished.
        If we do, iPad will try to center the focused element while the transition
@@ -607,6 +603,10 @@ H5P.Flashcards = (function ($, XapiGenerator) {
     $card.removeClass('h5p-previous h5p-next');
     $card.addClass('h5p-current');
     $card.attr('aria-hidden', 'false');
+
+    // Set unreacable for tab button
+    $card.find('.h5p-flashcard-overlay').attr('tabindex', '-1');
+    $card.siblings().find('.h5p-flashcard-overlay').attr('tabindex', '-1');
 
     $card.siblings()
       .removeClass('h5p-current h5p-previous h5p-next left right')

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -592,7 +592,9 @@ H5P.Flashcards = (function ($, XapiGenerator) {
        is running, and the card will be misplaced */
     $card.one('transitionend', function () {
       if ($card.hasClass('h5p-current') && !$card.find('.h5p-textinput')[0].disabled) {
+        $card.attr('aria-hidden', 'false');
         $card.find('.h5p-textinput').focus();
+        $card.siblings().attr('aria-hidden', 'true');
       }
       setTimeout(function () {
         this.announceCurrentPage();
@@ -602,11 +604,9 @@ H5P.Flashcards = (function ($, XapiGenerator) {
     // Update card classes
     $card.removeClass('h5p-previous h5p-next');
     $card.addClass('h5p-current');
-    $card.attr('aria-hidden', 'false');
 
     $card.siblings()
       .removeClass('h5p-current h5p-previous h5p-next left right')
-      .attr('aria-hidden', 'true')
       .find('.h5p-rotate-in').removeClass('h5p-rotate-in');
 
     $card.prev().addClass('h5p-previous');

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -36,7 +36,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
       results: "Results",
       ofCorrect: "@score of @total correct",
       showResults: "Show results",
-      retry : "Retry",
+      retry: "Retry",
       cardAnnouncement: 'Incorrect answer. Correct answer was @answer',
       pageAnnouncement: 'Page @current of @total',
       correctAnswerAnnouncement: '@answer is correct!'
@@ -328,7 +328,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     // Generate a new flashcards html and add it to h5p-inner
     var $card = $(
-      '<div role="group" aria-roledescription="slide" aria-labelledby="h5p-flashcard-card-' + cardId + '" class="h5p-card h5p-animate' + (index === 0 ? ' h5p-current' : '') + '"> ' +
+      '<div role="group" class="h5p-card h5p-animate' + (index === 0 ? ' h5p-current' : '') + '"> ' +
         '<div class="h5p-cardholder">' +
           '<div class="h5p-imageholder">' +
             '<div class="h5p-flashcard-overlay">' +

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -352,7 +352,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     $card.find('.h5p-imageholder').prepend(this.$images[index]);
 
-    $card.prepend($('<div class="h5p-flashcard-overlay" tabindex= "0"></div>').on('click', function () {
+    $card.prepend($('<div class="h5p-flashcard-overlay" tabindex="0"></div>').on('click', function () {
       
       // Set temporary focus
       $card.find('.h5p-flashcard-overlay').focus();
@@ -382,6 +382,9 @@ H5P.Flashcards = (function ($, XapiGenerator) {
       var userAnswer = $input.val().trim();
       var userCorrect = isCorrectAnswer(card, userAnswer, that.options.caseSensitive);
       var done = false;
+
+      // Set temporary focus
+      $card.find('.h5p-flashcard-overlay').focus();
 
       if (userAnswer == '') {
         $input.focus();

--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -352,7 +352,11 @@ H5P.Flashcards = (function ($, XapiGenerator) {
 
     $card.find('.h5p-imageholder').prepend(this.$images[index]);
 
-    $card.prepend($('<div class="h5p-flashcard-overlay"></div>').on('click', function () {
+    $card.prepend($('<div class="h5p-flashcard-overlay" tabindex= "0"></div>').on('click', function () {
+      
+      // Set temporary focus
+      $card.find('.h5p-flashcard-overlay').focus();
+      
       if ($(this).parent().hasClass('h5p-previous')) {
         that.previous();
       }
@@ -568,8 +572,13 @@ H5P.Flashcards = (function ($, XapiGenerator) {
    *   Class to add to existing current card.
    */
   C.prototype.setCurrent = function ($card) {
+    
+    // Set unreachable for tab button
+    $card.find('.h5p-flashcard-overlay').attr('tabindex', '-1');
+
     // Remove from existing card.
     if (this.$current) {
+      this.$current.attr('aria-hidden', 'true');
       this.$current.find('.h5p-textinput').attr('tabindex', '-1');
       this.$current.find('.joubel-tip-container').attr('tabindex', '-1');
       this.$current.find('.h5p-check-button').attr('tabindex', '-1');
@@ -584,6 +593,7 @@ H5P.Flashcards = (function ($, XapiGenerator) {
        is running, and the card will be misplaced */
     $card.one('transitionend', function () {
       if ($card.hasClass('h5p-current') && !$card.find('.h5p-textinput')[0].disabled) {
+        $card.attr('aria-hidden', 'false');
         $card.find('.h5p-textinput').focus();
       }
       setTimeout(function () {
@@ -594,7 +604,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
     // Update card classes
     $card.removeClass('h5p-previous h5p-next');
     $card.addClass('h5p-current');
-    $card.attr('aria-hidden', 'false');
 
     $card.siblings()
       .removeClass('h5p-current h5p-previous h5p-next left right')


### PR DESCRIPTION
Adds a fix on [issue HFP-3780](https://h5ptechnology.atlassian.net/browse/HFP-3780). Sets temporary focus on card transitions, before the 'setCurrent' method.