### PR TITLE
Remove auto-focus to avoid screenreader interruption

### DIFF
--- a/js/flashcards.js
+++ b/js/flashcards.js
@@ -593,7 +593,6 @@ H5P.Flashcards = (function ($, XapiGenerator) {
     $card.one('transitionend', function () {
       if ($card.hasClass('h5p-current') && !$card.find('.h5p-textinput')[0].disabled) {
         $card.attr('aria-hidden', 'false');
-        $card.find('.h5p-textinput').focus();
         $card.siblings().attr('aria-hidden', 'true');
       }
       setTimeout(function () {


### PR DESCRIPTION
This PR deals with an issue where screenreaders are cut off when reading the correct answer of incorrectly answered flashcard.

The cause of this issue is a fixed 3500ms timeout that focuses on the input of the next flashcard after answering the current flashcard. Since the focus is set explicity, the screenreader stops any text currently being read and immediately reads the newly focused element, [as it should from a UX perspective](https://stackoverflow.com/questions/75070407/how-can-i-prevent-the-screen-reader-from-stopping-to-read-the-content-when-the-f#:~:text=the%20live%20region.-,Change%20of%20focus,-However%20and%20in). There are three possible solutions to this issue that I can think of:

1. Remove the auto-focus, meaning the user would need to tab into the input of the new card after the transition.
2. Set the timeout length to be dependent on the length of the answer text (ie. answer.length * someFactor). Note this variance in timeout length would exist for all users, not just screenreader users.
3. Instead of auto-transitioning to next flashcard after answering, make the user explicitly navigate to the next arrow button to move to the next flashcard.

This PR implements solution #1 as it's the least disruptive to the current behaviour. Please feel free to comment on this PR if you feel there's a better solution.